### PR TITLE
drop-in replacement: `graceful-fs`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const {AsyncQueue} = require('@doctormckay/stdlib').DataStructures;
 const {EventEmitter} = require('events');
-const FS = require('fs');
+const FS = require('graceful-fs');
 const Path = require('path');
 const Util = require('util');
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"url": "https://github.com/DoctorMcKay/node-file-manager.git"
 	},
 	"dependencies": {
-		"@doctormckay/stdlib": "^1.14.1"
+		"@doctormckay/stdlib": "^1.14.1",
+		"graceful-fs": "^4.2.10"
 	},
 	"engines": {
 		"node": ">=8.0.0"


### PR DESCRIPTION
It provides many benefits, especially this:
> The goal is to trade EMFILE errors for slower fs operations. So, if you try to open a zillion files, rather than crashing, open operations will be queued up and wait for something else to close.